### PR TITLE
run in the morning instead of at midnight

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -2,7 +2,7 @@ name: Merge PRs with today's posts
 
 on:
   schedule:
-    - cron: "0 0 * * *" # Runs once a day at midnight UTC
+    - cron: "0 6 * * *" # Runs once a day at 6 AM UTC
   workflow_dispatch: # Allows manual trigger
 
 jobs:


### PR DESCRIPTION
Maybe because of summer/winter time it didn't publish [the Quai article.](https://github.com/Roald87/roaldin.ch/pull/152) It was merges, but it didn't show up in the published site. Therefore changing to 6 AM in the morning to publish.